### PR TITLE
메인페이지 메인 레이아웃 부분 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@mui/base": "^5.0.0-beta.68",
         "@mui/material": "^6.4.0",
+        "@mui/x-date-pickers": "^7.23.6",
         "@tanstack/react-query": "^5.62.2",
         "@tanstack/react-query-devtools": "^5.62.2",
         "@testing-library/jest-dom": "^5.17.0",
@@ -21,6 +23,7 @@
         "@types/react": "^18.3.13",
         "@types/react-dom": "^18.3.1",
         "axios": "^1.7.9",
+        "dayjs": "^1.11.13",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.0.2",
@@ -2661,6 +2664,44 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -3169,6 +3210,38 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
     },
+    "node_modules/@mui/base": {
+      "version": "5.0.0-beta.68",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.68.tgz",
+      "integrity": "sha512-F1JMNeLS9Qhjj3wN86JUQYBtJoXyQvknxlzwNl6eS0ZABo1MiohMONj3/WQzYPSXIKC2bS/ZbyBzdHhi2GnEpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@floating-ui/react-dom": "^2.1.1",
+        "@mui/types": "^7.2.20",
+        "@mui/utils": "^6.3.0",
+        "@popperjs/core": "^2.11.8",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.0.tgz",
@@ -3384,6 +3457,92 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
       "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
       "license": "MIT"
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.23.6.tgz",
+      "integrity": "sha512-jt6rEAYLju3NZe3y2S+I5KcTiSHV79FW0jeNUEUTceg1qsPzseHbND66k3zVF0hO3N2oZtLtPywof6vN5Doe+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0",
+        "@mui/x-internals": "7.23.6",
+        "@types/react-transition-group": "^4.4.11",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.23.6.tgz",
+      "integrity": "sha512-hT1Pa4PNCnxwiauPbYMC3p4DiEF1x05Iu4C1MtC/jMJ1LtthymLmTuQ6ZQ53/R9FeqK6sYd6A6noR+vNMjp5DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -6985,6 +7144,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.7",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@mui/base": "^5.0.0-beta.68",
     "@mui/material": "^6.4.0",
+    "@mui/x-date-pickers": "^7.23.6",
     "@tanstack/react-query": "^5.62.2",
     "@tanstack/react-query-devtools": "^5.62.2",
     "@testing-library/jest-dom": "^5.17.0",
@@ -16,6 +18,7 @@
     "@types/react": "^18.3.13",
     "@types/react-dom": "^18.3.1",
     "axios": "^1.7.9",
+    "dayjs": "^1.11.13",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.0.2",

--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,7 @@
-.App {
-  text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: url('https://via.placeholder.com/1920x1080') no-repeat center center fixed;
+  background-size: cover;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,14 @@
-import React from 'react'
-import logo from './logo.svg'
-import './App.css'
+import React from "react";
+import "./App.css";
+import Layout from "./components/layouts/Layout";
+import ReservationPart from "./components/ReservationPart";
 
-function App() {
+const App: React.FC = () => {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
-  )
-}
+    <Layout>
+      <ReservationPart />
+    </Layout>
+  );
+};
 
-export default App
+export default App;

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,13 +1,11 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom"
 import App from "./App"
-import Main from "./pages/main";
 
 const Router = () => {
     return (
         <BrowserRouter>
             <Routes>
                 <Route path="/" element={<App />} />
-                <Route path="/main" element={<Main />} />
             </Routes>
         </BrowserRouter>
     );

--- a/src/TicketPart.css
+++ b/src/TicketPart.css
@@ -1,0 +1,3 @@
+.ticket-reservation-container {
+    display: inline-flex;
+}

--- a/src/components/Dropdowns/DatePicker.tsx
+++ b/src/components/Dropdowns/DatePicker.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import dayjs, { Dayjs } from 'dayjs';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+function SelectDate() {
+    const [departureDate, setDepartureDate] = React.useState<Dayjs | null>(null); // 출발 날짜
+    const [arrivalDate, setArrivalDate] = React.useState<Dayjs | null>(null);     // 도착 날짜
+
+    // 출발 날짜 변경 핸들러
+    const handleDepartureDateChange = (newValue: Dayjs | null) => {
+        setDepartureDate(newValue);
+        // 출발 날짜가 도착 날짜보다 이후라면 도착 날짜를 초기화
+        if (arrivalDate && newValue && newValue.isAfter(arrivalDate)) {
+            setArrivalDate(null);
+        }
+    };
+
+    // 도착 날짜 변경 핸들러
+    const handleArrivalDateChange = (newValue: Dayjs | null) => {
+        setArrivalDate(newValue);
+    };
+
+    return (
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+            <Box
+                sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 2,
+                    width: '100%',
+                    maxWidth: 300, // 부모 컨테이너 크기 제한
+                    margin: 'auto',
+                }}
+            >
+                <Typography variant="h6" align="center">
+                    날짜 선택
+                </Typography>
+
+                {/* 출발 날짜 선택 */}
+                <DatePicker
+                    label="출발 날짜"
+                    showDaysOutsideCurrentMonth
+                    format="YYYY / MM / DD"
+                    value={departureDate}
+                    onChange={handleDepartureDateChange}
+                    localeText={{
+                        cancelButtonLabel: '취소',
+                        clearButtonLabel: '지우기',
+                        todayButtonLabel: '오늘',
+                        okButtonLabel: '확인',
+                        previousMonth: '이전 달',
+                        nextMonth: '다음 달',
+                        start: '시작',
+                        end: '종료',
+                    }}
+                    slotProps={{
+                        textField: {
+                            fullWidth: true,
+                            error: !!departureDate && !!arrivalDate && departureDate.isAfter(arrivalDate),
+                            helperText: !!departureDate && !!arrivalDate && departureDate.isAfter(arrivalDate)
+                                ? '출발 날짜는 도착 날짜 이전이어야 합니다.'
+                                : '',
+                        },
+                    }}
+                />
+
+                {/* 도착 날짜 선택 */}
+                <DatePicker
+                    label="도착 날짜"
+                    showDaysOutsideCurrentMonth
+                    format="YYYY / MM / DD"
+                    value={arrivalDate}
+                    onChange={handleArrivalDateChange}
+                    minDate={departureDate || undefined} // 출발 날짜 이후로만 선택 가능
+                    localeText={{
+                        cancelButtonLabel: '취소',
+                        clearButtonLabel: '지우기',
+                        todayButtonLabel: '오늘',
+                        okButtonLabel: '확인',
+                        previousMonth: '이전 달',
+                        nextMonth: '다음 달',
+                        start: '시작',
+                        end: '종료',
+                    }}
+                    slotProps={{
+                        textField: {
+                            fullWidth: true,
+                        },
+                    }}
+                />
+            </Box>
+        </LocalizationProvider>
+    );
+}
+
+export default SelectDate;

--- a/src/components/Dropdowns/Location.tsx
+++ b/src/components/Dropdowns/Location.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import { SelectChangeEvent } from '@mui/material/Select'; // MUI의 SelectChangeEvent 타입
+
+export default function LocationSelect() {
+    const [from, setFrom] = React.useState<string>('서울');
+    const [to, setTo] = React.useState<string>('부산');
+
+    const handleFromChange = (event: SelectChangeEvent<string>) => {
+        setFrom(event.target.value);
+    };
+
+    const handleToChange = (event: SelectChangeEvent<string>) => {
+        setTo(event.target.value);
+    };
+
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 2,
+            }}
+        >
+            {/* 출발지 선택 */}
+            <Box>
+                <Typography variant="body1" sx={{ marginBottom: 1 }}>
+                    From
+                </Typography>
+                <Select
+                    value={from}
+                    onChange={handleFromChange}
+                    displayEmpty
+                    sx={{ width: 120 }}
+                >
+                    <MenuItem value="서울">서울</MenuItem>
+                    <MenuItem value="부산">부산</MenuItem>
+                    <MenuItem value="제주">제주</MenuItem>
+                    <MenuItem value="대구">대구</MenuItem>
+                </Select>
+            </Box>
+
+            <Typography variant="body1">=</Typography>
+
+            {/* 도착지 선택 */}
+            <Box>
+                <Typography variant="body1" sx={{ marginBottom: 1 }}>
+                    To
+                </Typography>
+                <Select
+                    value={to}
+                    onChange={handleToChange}
+                    displayEmpty
+                    sx={{ width: 120 }}
+                >
+                    <MenuItem value="서울">서울</MenuItem>
+                    <MenuItem value="부산">부산</MenuItem>
+                    <MenuItem value="제주">제주</MenuItem>
+                    <MenuItem value="대구">대구</MenuItem>
+                </Select>
+            </Box>
+        </Box>
+    );
+}

--- a/src/components/Dropdowns/Passenger.tsx
+++ b/src/components/Dropdowns/Passenger.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import { FormHelperText, Box, Typography } from '@mui/material';
+
+export default function Passenger() {
+  const [adults, setAdults] = React.useState<number>(1); // 성인 수 상태
+  const [children, setChildren] = React.useState<number>(0); // 아동 수 상태
+  const maxPassengers = 9; // 최대 인원 제한
+
+  // 성인 수 변경 핸들러
+  const handleAdultsChange = (event: SelectChangeEvent<number>) => {
+    const value = Number(event.target.value);
+    if (value + children <= maxPassengers) {
+      setAdults(value);
+    }
+  };
+
+  // 아동 수 변경 핸들러
+  const handleChildrenChange = (event: SelectChangeEvent<number>) => {
+    const value = Number(event.target.value);
+    if (adults + value <= maxPassengers) {
+      setChildren(value);
+    }
+  };
+
+  return (
+    <Box
+      className="passenger-text-container"
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        margin: '20px',
+        alignItems: 'center',
+      }}
+    >
+      <Typography variant="h6" align="center">
+        탑승 인원
+      </Typography>
+      <Box
+        className="passenger-container"
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 2,
+          justifyContent: 'center',
+        }}
+      >
+
+        {/* 성인 수 선택 */}
+        <FormControl sx={{ minWidth: 120 }}>
+          <InputLabel id="grouped-adult-label">성인</InputLabel>
+          <Select
+            labelId="grouped-adult-label"
+            value={adults}
+            onChange={handleAdultsChange}
+            label="성인"
+          >
+            {Array.from({ length: maxPassengers }, (_, i) => (
+              <MenuItem key={i + 1} value={i + 1}>
+                {i + 1}명
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        {/* 아동 수 선택 */}
+        <FormControl sx={{ minWidth: 120 }}>
+          <InputLabel id="grouped-children-label">아동</InputLabel>
+          <Select
+            labelId="grouped-children-label"
+            value={children}
+            onChange={handleChildrenChange}
+            label="아동"
+          >
+            {Array.from({ length: maxPassengers + 1 }, (_, i) => (
+              <MenuItem key={i} value={i}>
+                {i}명
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+
+      {/* 유효성 검사 및 경고 메시지 */}
+      <FormHelperText>
+        최대 {maxPassengers}인까지 예매 가능합니다. 현재 인원: {adults + children}명
+      </FormHelperText>
+    </Box>
+  );
+}

--- a/src/components/Dropdowns/Seatclass.tsx
+++ b/src/components/Dropdowns/Seatclass.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import { Typography } from '@mui/material';
+
+export default function SeatClass() {
+    const [seatClass, setSeatClass] = React.useState<string>('1'); // 초기값: 일반석
+
+    const handleChange = (event: SelectChangeEvent<string>) => {
+        setSeatClass(event.target.value);
+    };
+
+    // 좌석 등급 데이터 (동적 생성 가능)
+    const seatOptions = [
+        { value: '1', label: '일반석' },
+        { value: '2', label: '프로라이언스석' },
+    ];
+
+    return (
+
+        <Box sx={{ minWidth: 120 }}>
+            <Typography variant="h6" align="center">
+                좌석등급
+            </Typography>
+            <FormControl sx={{ m: 1, width: 175 }}>
+                <InputLabel id="seatclass-select-label">좌석등급</InputLabel>
+                <Select
+                    labelId="seatclass-select-label"
+                    id="seatclass-select"
+                    value={seatClass}
+                    onChange={handleChange}
+                    label="좌석등급"
+                >
+                    {seatOptions.map((option) => (
+                        <MenuItem key={option.value} value={option.value}>
+                            {option.label}
+                        </MenuItem>
+                    ))}
+                </Select>
+            </FormControl>
+        </Box>
+    );
+}

--- a/src/components/ReservationPart.tsx
+++ b/src/components/ReservationPart.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import Box from "@mui/material/Box";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import Divider from "@mui/material/Divider";
+import SelectDate from "./Dropdowns/DatePicker";
+import LocationSelect from "./Dropdowns/Location";
+import Passenger from "./Dropdowns/Passenger";
+import SeatClass from "./Dropdowns/Seatclass";
+
+export default function ReservationPart() {
+    return (
+        <Box
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 4,
+                margin: "0 20vw",
+            }}
+        >
+            <Box
+                sx={{
+                    display: "flex",
+                    alignItems: "stretch",
+                }}
+            >
+                {/* 항공권 예매 */}
+                <Paper
+                    elevation={3}
+                    sx={{
+                        flex: 1, // 비율 1
+                        padding: 2,
+                        display: "flex",
+                        flexDirection: "column",
+                    }}
+                >
+                    <Box sx={{ marginTop: 2 }}>
+                        <LocationSelect />
+                    </Box>
+                </Paper>
+
+                {/* 마일리지 예매 */}
+                <Paper
+                    elevation={3}
+                    sx={{
+                        flex: 2, // 비율 2 (더 넓게 설정)
+                        padding: 2,
+                        display: "flex",
+                        flexDirection: "column",
+                    }}
+                >
+                    <Box
+                        sx={{
+                            display: "flex",
+                            gap: 2,
+                            marginTop: 2,
+                        }}
+                    >
+                        <SelectDate />
+                        <Passenger />
+                        <SeatClass />
+                    </Box>
+                </Paper>
+            </Box>
+        </Box>
+    );
+}

--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -1,0 +1,8 @@
+const Footer = () => {
+    return (
+        <div className="footer-container" style={{ height: "250px" }}>
+            <footer>푸터 컴포넌트 입니다.</footer>
+        </div>
+    )
+}
+export default Footer

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,0 +1,12 @@
+const Header = () => {
+    return (
+        <div className="header-container"
+            style={{
+                height: '250px',
+            }}
+        >
+            <header>Proaliance</header>
+        </div>
+    )
+}
+export default Header

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,0 +1,15 @@
+import Footer from "./Footer";
+import Header from "./Header";
+
+const Layout = (props: { children: React.ReactNode }) => {
+    return (
+        <>
+            <Header />
+
+            <main>{props.children}</main>
+            <Footer />
+        </>
+    )
+}
+
+export default Layout

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
-import reportWebVitals from './reportWebVitals';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Router from './Router';
 
@@ -14,12 +13,7 @@ const queryClient = new QueryClient();
 root.render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-        <Router/>
+      <Router />
     </QueryClientProvider>
   </React.StrictMode>
 );
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();

--- a/src/pages/main.tsx
+++ b/src/pages/main.tsx
@@ -1,5 +1,0 @@
-function Main() {
-    return (<p>page home</p>)
-};
-
-export default Main;


### PR DESCRIPTION
### ✔구현한 것
1. 날짜 선택: mui 라이브러리의 datepicker를 이용함
2. 탑승 인원, 좌석등급 선택: mui의 select 이용함

### ❌ 해야할 것
1. 출발지-목적지 선택: 'From'과 'To' 글자를 눌렀을 때 선택창이 나타나도록 구현해야함
2. 레이아웃 수정: 좌석등급 선택하는 곳의 레이아웃이 안맞음
3. 헤더 구현: 헤더에 "ProAliance" 보이게 해야하는데, 이미지로 할지 typography로 할지 고민
4. 배경 이미지 삽입
5. 서버 연결 부위 구현: 일단 css만 구현해 둔 거라 서버랑 연결할 때 얼마나 부딪힐지 모르겠다..

### 🤝어려웠던 것
1. Datepicker: 공식문서가 잘 나와있는 것 같긴 한데 영어라서 그런지 힘들었다.
2. 레이아웃 : mui 라이브러리는 div 말고 box를 이용해서 낯설다. 이쁘니까 용서해준다.